### PR TITLE
Add simplified AlphaZero chess skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# testgpt
+# AlphaZero Chess (Simplified)
+
+This repository contains a minimal educational implementation of an
+AlphaZero-style chess engine in pure Python. The goal is to showcase
+the general structure of Monte Carlo Tree Search (MCTS) combined with a
+neural network-like policy/value predictor. Because this environment
+lacks external dependencies, the "network" is a random placeholder and
+the chess rules are simplified.
+
+## Running a Self-Play Game
+
+```bash
+python -m alphazero_chess.self_play
+```
+
+## Running Tests
+
+```bash
+pytest
+```

--- a/alphazero_chess/board.py
+++ b/alphazero_chess/board.py
@@ -1,0 +1,131 @@
+from dataclasses import dataclass
+from typing import List, Tuple
+
+Piece = str
+Square = Tuple[int, int]
+
+@dataclass(frozen=True)
+class Move:
+    start: Square
+    end: Square
+    capture: bool = False
+
+class Board:
+    """Simple chess board representation.
+
+    This is a minimal board implementation that supports basic piece movement.
+    It does not handle all chess rules like castling, en passant or check.
+    It is meant as a lightweight environment for AlphaZero-style algorithms.
+    """
+
+    def __init__(self):
+        # Standard chess starting position
+        self.board: List[List[Piece]] = [
+            list("rnbqkbnr"),
+            ["p"]*8,
+            [" "]*8,
+            [" "]*8,
+            [" "]*8,
+            [" "]*8,
+            ["P"]*8,
+            list("RNBQKBNR"),
+        ]
+        self.turn: str = "white"  # 'white' or 'black'
+
+    def in_bounds(self, sq: Square) -> bool:
+        r, c = sq
+        return 0 <= r < 8 and 0 <= c < 8
+
+    def piece_at(self, sq: Square) -> Piece:
+        r, c = sq
+        return self.board[r][c]
+
+    def move_piece(self, move: Move):
+        sr, sc = move.start
+        er, ec = move.end
+        piece = self.board[sr][sc]
+        self.board[sr][sc] = " "
+        self.board[er][ec] = piece
+        self.turn = "black" if self.turn == "white" else "white"
+
+    def generate_pseudo_legal_moves(self) -> List[Move]:
+        moves: List[Move] = []
+        for r in range(8):
+            for c in range(8):
+                p = self.board[r][c]
+                if p == " ":
+                    continue
+                if self.turn == "white" and p.isupper():
+                    moves.extend(self._piece_moves((r, c), p))
+                elif self.turn == "black" and p.islower():
+                    moves.extend(self._piece_moves((r, c), p))
+        return moves
+
+    def _piece_moves(self, sq: Square, piece: Piece) -> List[Move]:
+        r, c = sq
+        moves: List[Move] = []
+        directions = []
+        if piece.lower() == "p":
+            direction = -1 if piece.isupper() else 1
+            start_row = 6 if piece.isupper() else 1
+            next_sq = (r + direction, c)
+            if self.in_bounds(next_sq) and self.piece_at(next_sq) == " ":
+                moves.append(Move((r, c), next_sq))
+                if r == start_row:
+                    jump_sq = (r + 2 * direction, c)
+                    if self.piece_at(jump_sq) == " ":
+                        moves.append(Move((r, c), jump_sq))
+            for dc in [-1, 1]:
+                cap_sq = (r + direction, c + dc)
+                if self.in_bounds(cap_sq):
+                    target = self.piece_at(cap_sq)
+                    if target != " " and target.isupper() != piece.isupper():
+                        moves.append(Move((r, c), cap_sq, capture=True))
+            return moves
+        elif piece.lower() == "n":
+            directions = [
+                (-2, -1), (-2, 1), (-1, -2), (-1, 2),
+                (1, -2), (1, 2), (2, -1), (2, 1)
+            ]
+        elif piece.lower() == "b":
+            directions = [(-1, -1), (-1, 1), (1, -1), (1, 1)]
+        elif piece.lower() == "r":
+            directions = [(-1, 0), (1, 0), (0, -1), (0, 1)]
+        elif piece.lower() == "q":
+            directions = [(-1, -1), (-1, 1), (1, -1), (1, 1), (-1, 0), (1, 0), (0, -1), (0, 1)]
+        elif piece.lower() == "k":
+            directions = [
+                (-1, -1), (-1, 0), (-1, 1),
+                (0, -1),          (0, 1),
+                (1, -1),  (1, 0), (1, 1)
+            ]
+            for dr, dc in directions:
+                nr, nc = r + dr, c + dc
+                if not self.in_bounds((nr, nc)):
+                    continue
+                target = self.piece_at((nr, nc))
+                if target == " " or target.isupper() != piece.isupper():
+                    moves.append(Move((r, c), (nr, nc), capture=target != " "))
+            return moves
+
+        for dr, dc in directions:
+            nr, nc = r + dr, c + dc
+            while self.in_bounds((nr, nc)):
+                target = self.piece_at((nr, nc))
+                if target == " ":
+                    moves.append(Move((r, c), (nr, nc)))
+                else:
+                    if target.isupper() != piece.isupper():
+                        moves.append(Move((r, c), (nr, nc), capture=True))
+                    break
+                if piece.lower() in ("n", "k"):
+                    break
+                nr += dr
+                nc += dc
+        return moves
+
+    def copy(self) -> 'Board':
+        new = Board()
+        new.board = [row[:] for row in self.board]
+        new.turn = self.turn
+        return new

--- a/alphazero_chess/mcts.py
+++ b/alphazero_chess/mcts.py
@@ -1,0 +1,77 @@
+import math
+import random
+from typing import Dict, List, Optional
+
+from .board import Board, Move
+from .network import RandomNetwork
+
+
+class TreeNode:
+    def __init__(self, board: Board, parent: Optional['TreeNode'] = None):
+        self.board = board
+        self.parent = parent
+        self.children: Dict[Move, 'TreeNode'] = {}
+        self.visit_count = 0
+        self.value_sum = 0.0
+        self.prior: Dict[Move, float] = {}
+
+    def q_value(self) -> float:
+        return self.value_sum / self.visit_count if self.visit_count else 0.0
+
+
+class MCTS:
+    def __init__(self, network: Optional[RandomNetwork] = None, c_puct: float = 1.0, simulations: int = 50):
+        self.network = network or RandomNetwork()
+        self.c_puct = c_puct
+        self.simulations = simulations
+
+    def select(self, node: TreeNode) -> TreeNode:
+        while node.children:
+            best_score = -float('inf')
+            best_move = None
+            for move, child in node.children.items():
+                prior = node.prior.get(move, 1.0 / len(node.children))
+                u = self.c_puct * prior * math.sqrt(node.visit_count) / (1 + child.visit_count)
+                score = child.q_value() + u
+                if score > best_score:
+                    best_score = score
+                    best_move = move
+            node = node.children[best_move]
+        return node
+
+    def expand(self, node: TreeNode):
+        moves = node.board.generate_pseudo_legal_moves()
+        policy = self.network.predict(node.board, moves)
+        node.prior = {mv: p for mv, p in zip(moves, policy)}
+        for move in moves:
+            next_board = node.board.copy()
+            next_board.move_piece(move)
+            node.children[move] = TreeNode(next_board, parent=node)
+
+    def simulate(self, node: TreeNode) -> float:
+        return self.network.value(node.board)
+
+    def backpropagate(self, path: List[TreeNode], value: float):
+        for node in reversed(path):
+            node.visit_count += 1
+            node.value_sum += value
+            value = -value
+
+    def run(self, board: Board) -> Move:
+        root = TreeNode(board.copy())
+        self.expand(root)
+        for _ in range(self.simulations):
+            node = root
+            path = [node]
+            while node.children:
+                node = self.select(node)
+                path.append(node)
+            if node.visit_count == 0:
+                value = self.simulate(node)
+            else:
+                self.expand(node)
+                value = self.simulate(node)
+            self.backpropagate(path, value)
+        # pick the most visited move from the root
+        best_move = max(root.children.items(), key=lambda item: item[1].visit_count)[0]
+        return best_move

--- a/alphazero_chess/network.py
+++ b/alphazero_chess/network.py
@@ -1,0 +1,20 @@
+import random
+from typing import List
+
+from .board import Board, Move
+
+class RandomNetwork:
+    """A placeholder neural network that outputs random policy and value."""
+
+    def predict(self, board: Board, moves: List[Move]) -> List[float]:
+        # return a random probability distribution over moves
+        n = len(moves)
+        if n == 0:
+            return []
+        probs = [random.random() for _ in range(n)]
+        total = sum(probs)
+        return [p / total for p in probs]
+
+    def value(self, board: Board) -> float:
+        # return a random value between -1 and 1
+        return random.uniform(-1.0, 1.0)

--- a/alphazero_chess/self_play.py
+++ b/alphazero_chess/self_play.py
@@ -1,0 +1,25 @@
+from .board import Board
+from .mcts import MCTS
+
+
+def play_game(simulations: int = 50):
+    board = Board()
+    mcts = MCTS(simulations=simulations)
+    moves = []
+    for _ in range(200):  # limit moves to avoid infinite games
+        move = mcts.run(board)
+        moves.append(move)
+        board.move_piece(move)
+        if not board.generate_pseudo_legal_moves():
+            break
+    return moves
+
+
+def main():
+    moves = play_game()
+    for mv in moves:
+        print(f"{mv.start}->{mv.end}{'x' if mv.capture else ''}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -1,0 +1,10 @@
+from alphazero_chess.board import Board
+
+
+def test_initial_moves():
+    b = Board()
+    moves = b.generate_pseudo_legal_moves()
+    # at least white pawns and knights should have moves
+    assert len(moves) > 0
+    # there should be 20 moves in the initial chess position (simplified)
+    assert len(moves) >= 16

--- a/tests/test_mcts.py
+++ b/tests/test_mcts.py
@@ -1,0 +1,10 @@
+from alphazero_chess.board import Board
+from alphazero_chess.mcts import MCTS
+
+
+def test_mcts_selects_move():
+    board = Board()
+    mcts = MCTS(simulations=5)
+    move = mcts.run(board)
+    assert move is not None
+    assert isinstance(move.start, tuple) and isinstance(move.end, tuple)


### PR DESCRIPTION
## Summary
- implement minimal chess board and move generation logic
- add a simple MCTS with a random policy/value network
- include self-play example and basic tests
- update README
- ignore Python cache files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684058745e4c832aa6f776c1f061f7dd